### PR TITLE
Prefer react named exports

### DIFF
--- a/src/DragComponent.js
+++ b/src/DragComponent.js
@@ -1,6 +1,6 @@
-import React from 'react'
-import store from './store'
+import * as React from 'react'
 import PropTypes from 'prop-types'
+import store from './store'
 
 class DragComponent extends React.Component {
   static defaultProps = {

--- a/src/DragState.js
+++ b/src/DragState.js
@@ -1,4 +1,4 @@
-import React from 'react'
+import * as React from 'react'
 import store from './store'
 
 class DragState extends React.Component {

--- a/src/Draggable.js
+++ b/src/Draggable.js
@@ -1,6 +1,6 @@
-import React from 'react'
-import store from './store'
+import * as React from 'react'
 import PropTypes from 'prop-types'
+import store from './store'
 
 class Draggable extends React.Component {
   static defaultProps = {

--- a/src/Droppable.js
+++ b/src/Droppable.js
@@ -1,4 +1,4 @@
-import React from 'react'
+import * as React from 'react'
 import PropTypes from 'prop-types'
 import store from './store'
 


### PR DESCRIPTION
One day react will distribute react as esm target and a lot of code will be broken. So I suggest to prefer always named exports for react. 